### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/components/bill/tabs/BillTab.tsx
+++ b/components/bill/tabs/BillTab.tsx
@@ -147,9 +147,21 @@ const BillTab = ({ summary, pdfUrl, metadata }: BillTabProps) => {
               <h2 className="text-xl font-semibold text-gray-800 border-b pb-2 mb-4">
                 Bill Document
               </h2>
-              <PdfViewer
-                fileUrl={`/api/proxy-pdf?url=${encodeURIComponent(pdfUrl)}`}
-              />
+              <div className="md:hidden">
+                <a
+                  href={`/api/proxy-pdf?url=${encodeURIComponent(pdfUrl)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  View PDF
+                </a>
+              </div>
+              <div className="hidden md:block">
+                <PdfViewer
+                  fileUrl={`/api/proxy-pdf?url=${encodeURIComponent(pdfUrl)}`}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -82,8 +82,8 @@ const Header = ({
       <Toaster position="bottom-right" richColors />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         {/* Breadcrumbs and Action Buttons */}
-        <div className="flex justify-between items-center">
-          <div className="flex items-center space-x-2 text-sm text-gray-500">
+        <div className="flex flex-col gap-2 md:flex-row md:justify-between md:items-center">
+          <div className="flex flex-wrap items-center text-sm text-gray-500 gap-2">
             <Link
               href={`/bill/${congress}`}
               className="font-semibold text-blue-600 cursor-pointer"
@@ -100,7 +100,7 @@ const Header = ({
             <ChevronsRight className="w-4 h-4 text-gray-400" />
             <span className="font-semibold">{billNumber}</span>
           </div>
-          <div className="flex items-center space-x-2">
+          <div className="flex flex-wrap items-center gap-2">
             <button
               onClick={handleWatch}
               className="flex items-center space-x-2 px-3 py-1.5 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer"
@@ -137,7 +137,7 @@ const Header = ({
           </div>
         </div>
         {/* Bill Title */}
-        <div className="mt-4 flex items-center">
+        <div className="mt-4 flex flex-col sm:flex-row sm:items-center gap-2">
           <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
           {isLaw && <LawBadge />}
         </div>

--- a/components/pages/BillPageComponent.tsx
+++ b/components/pages/BillPageComponent.tsx
@@ -116,8 +116,8 @@ const BillPageComponent = ({
       />
 
       <div className="border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <nav className="-mb-px flex space-x-4" aria-label="Tabs">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 overflow-x-auto overflow-y-hidden">
+          <nav className="-mb-px flex space-x-4 min-w-max" aria-label="Tabs">
             {tabs.map((tab) => (
               <Tab
                 key={tab.name}

--- a/components/pages/TrendingBills.tsx
+++ b/components/pages/TrendingBills.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, ScrollText, Pencil, Hash } from "lucide-react";
+import { ScrollText, Pencil, Hash } from "lucide-react";
 import Link from "next/link";
 import { formatCongress, getBillTypeAlias } from "@/lib/utils";
 
@@ -31,7 +31,7 @@ const TrendingBills = ({
           {trendingBills.map((bill) => (
             <li
               key={bill.rank}
-              className="flex items-center justify-between gap-x-6 py-5 hover:bg-gray-50 px-2 rounded-md"
+              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 py-5 hover:bg-gray-50 px-2 rounded-md"
             >
               <div className="flex min-w-0 gap-x-4">
                 <span className="text-2xl font-bold text-gray-400 w-8 text-center">
@@ -46,7 +46,7 @@ const TrendingBills = ({
                       {bill.title}
                     </Link>
                   </p>
-                  <div className="mt-1 flex items-center gap-x-4 text-xs leading-5 text-gray-500">
+                  <div className="mt-1 flex flex-wrap items-center gap-x-4 text-xs leading-5 text-gray-500">
                     <div className="flex items-center gap-x-1">
                       <ScrollText className="h-4 w-4" />
                       <span>{formatCongress(bill.congress)}</span>
@@ -68,7 +68,7 @@ const TrendingBills = ({
               </div>
               <Link
                 href={`/bill/${bill.congress}/${bill.type}/${bill.number}`}
-                className="rounded-full bg-white px-3.5 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100 flex-shrink-0"
+                className="mt-2 sm:mt-0 self-start sm:self-auto rounded-full bg-white px-3.5 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100"
               >
                 View Bill
               </Link>


### PR DESCRIPTION
### 📱 What Changed
- **📄 Mobile PDF handling**: On small screens, replaced inline `PdfViewer` with a “View PDF” 🔗 that opens in a new tab via `/api/proxy-pdf?url=...`; keep `PdfViewer` for `md+` screens. 🚀 Improves mobile performance and stability. (`components/bill/tabs/BillTab.tsx`)
- **🧑‍💼 Responsive header layout**: Breadcrumbs/actions now wrap and stack on small screens; title stacks with `LawBadge` 🏷️ on mobile and aligns inline on larger screens. (`components/layout/Header.tsx`)
- **↔️ Scrollable tabs on mobile**: Tabs container gains horizontal scroll with `overflow-x-auto` and `min-w-max` to prevent cramped wrapping. (`components/pages/BillPageComponent.tsx`)
- **📈 Responsive trending list**: Items stack on mobile, metadata wraps, and the “View Bill” button 📝 positions sensibly across breakpoints; removed unused `MessageSquare` import. (`components/pages/TrendingBills.tsx`)

### ❓ Why
- **⚡ Performance**: Avoid heavy embedded PDF rendering on mobile.
- **👌 Usability**: Better readability, wrapping, and touch targets on small screens.
- **🖥️ Parity**: Preserve desktop layout/behavior while optimizing mobile UX.

### 🗂️ Affected Files
- `components/bill/tabs/BillTab.tsx`
- `components/layout/Header.tsx`
- `components/pages/BillPageComponent.tsx`
- `components/pages/TrendingBills.tsx`

### ✅ QA Checklist
- 📄 Mobile bill page shows “View PDF” link that opens in a new tab; no inline PDF render.
- 🧑‍💼 Header breadcrumbs/actions wrap; title and `LawBadge` stack on small screens.
- ↔️ Tabs are horizontally scrollable on small screens; no overflow clipping.
- 📈 Trending list stacks nicely on mobile; “View Bill” button remains visible and usable.
- 🖥️ Desktop behavior remains unchanged for all pages.

- 🚀 Implemented mobile-friendly PDF handling, responsive header, scrollable tabs, and responsive trending list; removed unused import.